### PR TITLE
Fix ModuleNotFoundError: No module named '_tkinter'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Kindleの蔵書情報を分析・可視化するためのツールです。
 
 - Python 3.8以上
 - [uv](https://github.com/astral-sh/uv)（高速なPythonパッケージマネージャー）
+- tkinter（グラフ表示用、インストールしない場合は一部機能に制限あり）
+  - macOS: `brew install python-tk`
+  - Ubuntu: `sudo apt-get install python3-tk`
+  - Windows: 通常はPythonインストール時に含まれています。含まれていない場合はPythonインストーラーを再実行して「tcl/tk and IDLE」オプションを選択してください。
 
 ### セットアップ手順
 


### PR DESCRIPTION
Fixes #1

## 問題
matplotlibがデフォルトでtkinterバックエンドを使用しようとするが、tkinterがインストールされていない環境で実行するとエラーが発生する問題。

## 解決策
READMEの前提条件にtkinterのインストール方法を追記しました。これにより、ユーザーは必要に応じてtkinterをインストールできるようになります。

- macOS: brew install python-tk
- Ubuntu: sudo apt-get install python3-tk
- Windows: 通常はPythonインストール時に含まれています